### PR TITLE
画像のalt textがないケースを許容する

### DIFF
--- a/src/easybooks-ast/review-stringify.test.ts
+++ b/src/easybooks-ast/review-stringify.test.ts
@@ -132,6 +132,19 @@ describe('strong', () => {
   })
 })
 
+describe('image', () => {
+  test('', () => {
+    expect(mdToReview('![fuga](hoge.png)')).resolves.toBe(
+      '\n//image[hoge.png][fuga]\n\n',
+    )
+  })
+  test('no alt', () => {
+    expect(mdToReview('![](piyo.png)')).resolves.toBe(
+      '\n//image[piyo.png]\n\n',
+    )
+  })
+})
+
 describe('table', () => {
   test('GFM table', () => {
     expect(

--- a/src/easybooks-ast/review-stringify.ts
+++ b/src/easybooks-ast/review-stringify.ts
@@ -130,7 +130,7 @@ const image = (tree: EBAST.Image, context: Context) => {
   const url = tree.url
     .replace(/^images\//, '')
     .replace(/\.[a-zA-Z0-9]$/, '')
-  return `//image[${url}][${tree.alt}]\n`
+  return `//image[${url}]${ tree.alt ? `[${tree.alt}]` : ''}\n`
 }
 
 const TableAlign = {


### PR DESCRIPTION
現在、画像のalt textを空にした場合、PDFでの表記が`null`となる。
利用者として空にした場合はキャプションが消えるのが自然だと思ったので実装しました。
（GitHubのmasterが最新版ではない雰囲気を感じています @erukiti ）

<img width="705" alt="スクリーンショット 2020-02-05 2 26 31" src="https://user-images.githubusercontent.com/7007253/73769960-efc14300-47be-11ea-96b4-ccc046d420ab.png">
