### PR TITLE
画像の拡張子を削除

### DIFF
--- a/src/easybooks-ast/review-stringify.test.ts
+++ b/src/easybooks-ast/review-stringify.test.ts
@@ -135,12 +135,12 @@ describe('strong', () => {
 describe('image', () => {
   test('', () => {
     expect(mdToReview('![fuga](hoge.png)')).resolves.toBe(
-      '\n//image[hoge.png][fuga]\n\n',
+      '\n//image[hoge][fuga]\n\n',
     )
   })
   test('no alt', () => {
     expect(mdToReview('![](piyo.png)')).resolves.toBe(
-      '\n//image[piyo.png]\n\n',
+      '\n//image[piyo]\n\n',
     )
   })
 })

--- a/src/easybooks-ast/review-stringify.ts
+++ b/src/easybooks-ast/review-stringify.ts
@@ -129,7 +129,7 @@ const comment = (tree: EBAST.Comment, context: Context) => {
 const image = (tree: EBAST.Image, context: Context) => {
   const url = tree.url
     .replace(/^images\//, '')
-    .replace(/\.[a-zA-Z0-9]$/, '')
+    .replace(/\.[a-zA-Z0-9]+$/, '')
   return `//image[${url}]${ tree.alt ? `[${tree.alt}]` : ''}\n`
 }
 


### PR DESCRIPTION
masterを動かしたところ、画像の拡張子が残ってしまって、Re:VIEWで画像を見つけられなくなっていました。
npmでインストールされる最新バージョンが0.1.27なので、非公開の開発版ではすでに修正された不具合かもしれませんが、一応PRいたします。