### PR TITLE
ネストされた章構造への対応

### DIFF
--- a/src/adapters/review/config.test.ts
+++ b/src/adapters/review/config.test.ts
@@ -51,4 +51,16 @@ describe('prepareConfig', () => {
     expect(templates).toEqual([])
     expect(sty_templates).toBeUndefined()
   })
+
+  test('nested catalog', () => {
+    const conf = {
+      catalog: { CHAPS: ['0.md', {'sec1': ['1-1.md', '1-2.md']}, {'sec2': ['2-1.md', '2-2.md']}] },
+    }
+
+    const { catalog, templates, sty_templates } = preparingConfig(conf)
+    expect(conf).toEqual({})
+    expect(catalog).toEqual({ CHAPS: ['0.md', {'sec1': ['1-1.md', '1-2.md']}, {'sec2': ['2-1.md', '2-2.md']}] })
+    expect(templates).toEqual([])
+    expect(sty_templates).toBeUndefined()
+  })
 })

--- a/src/adapters/review/config.test.ts
+++ b/src/adapters/review/config.test.ts
@@ -54,12 +54,12 @@ describe('prepareConfig', () => {
 
   test('nested catalog', () => {
     const conf = {
-      catalog: { CHAPS: ['0.md', {'sec1': ['1-1.md', '1-2.md']}, {'sec2': ['2-1.md', '2-2.md']}] },
+      catalog: { CHAPS: ['0.md', {'sec1': ['1-1.md', '1-2.md']}, {'sec2.md': ['2-1.md', '2-2.md']}] },
     }
 
     const { catalog, templates, sty_templates } = preparingConfig(conf)
     expect(conf).toEqual({})
-    expect(catalog).toEqual({ CHAPS: ['0.md', {'sec1': ['1-1.md', '1-2.md']}, {'sec2': ['2-1.md', '2-2.md']}] })
+    expect(catalog).toEqual({ CHAPS: ['0.md', {'sec1': ['1-1.md', '1-2.md']}, {'sec2.md': ['2-1.md', '2-2.md']}] })
     expect(templates).toEqual([])
     expect(sty_templates).toBeUndefined()
   })

--- a/src/adapters/review/tasks.ts
+++ b/src/adapters/review/tasks.ts
@@ -55,7 +55,13 @@ export const createCatalog = (
       if (typeof filename !== 'string') {
         const namedEntry: { [key: string]: any[]; } = {}
         for (const key of Object.keys(filename)) {
-          namedEntry[key] = filename[key].map(processEntry)
+          if (key.endsWith('.md')) {
+            const reviewFilename = key.replace(/\.md$/, '.re')
+            tasks.push(convert(files, key, reviewFilename))
+            namedEntry[reviewFilename] = filename[key].map(processEntry)
+          } else {
+            namedEntry[key] = filename[key].map(processEntry)
+          }
         }
         return namedEntry
       } else if (filename.endsWith('.md')) {

--- a/src/adapters/review/tasks.ts
+++ b/src/adapters/review/tasks.ts
@@ -51,9 +51,14 @@ export const createCatalog = (
   catalog: Catalog,
 ) => {
   const tasks: Promise<any>[] = []
-  Object.keys(catalog).map(key => {
-    catalog[key] = catalog[key].map(filename => {
-      if (filename.endsWith('.md')) {
+  const processEntry = (filename: any) => {
+      if (typeof filename !== 'string') {
+        const namedEntry: { [key: string]: any[]; } = {}
+        for (const key of Object.keys(filename)) {
+          namedEntry[key] = filename[key].map(processEntry)
+        }
+        return namedEntry
+      } else if (filename.endsWith('.md')) {
         const reviewFilename = filename.replace(/\.md$/, '.re')
         tasks.push(convert(files, filename, reviewFilename))
         return reviewFilename
@@ -64,7 +69,9 @@ export const createCatalog = (
         tasks.push(copy())
         return filename
       }
-    })
+    }
+  Object.keys(catalog).map(key => {
+    catalog[key] = catalog[key].map(processEntry)
   })
 
   return { catalog, tasks }

--- a/src/ports/build-book.ts
+++ b/src/ports/build-book.ts
@@ -7,7 +7,7 @@ export interface ConfigReview {
 }
 
 export interface Catalog {
-  [props: string]: string[]
+  [props: string]: any[]
 }
 
 export type Config = ConfigReview & {


### PR DESCRIPTION
https://github.com/kmuto/review/blob/master/doc/catalog.ja.md#catalogyml-%E3%82%92%E7%94%A8%E3%81%84%E3%81%9F%E5%A0%B4%E5%90%88%E3%81%AE%E8%A8%AD%E5%AE%9A%E6%96%B9%E6%B3%95 に記載があるネストされた章構造への対応です。
いかがでしょうか？

仕様上文字列とハッシュが同じ配列の中に現れるようなのですが、文字列とオブジェクトの両方を取れる型をどう表現すれば良いか分からなかったので、とりあえず型はanyとしています。
TypeScript初心者なので、適切な書き方になっていないのではないかと心配しています。

npmでインストールされる最新バージョンが0.1.27なので、非公開の開発版ではすでに対応されているかもしれませんが、一応PRいたします。