### PR TITLE
番号付き箇条書きに対応

### DIFF
--- a/src/easybooks-ast/review-stringify.test.ts
+++ b/src/easybooks-ast/review-stringify.test.ts
@@ -81,6 +81,7 @@ describe('list', () => {
 describe('ordered list', () => {
   test('', async () => {
     expect(await mdToReview('1. hoge\n2. fuga')).toBe(' 1. hoge\n 2. fuga\n\n')
+    expect(await mdToReview('3. hoge\n4. fuga')).toBe(' 3. hoge\n 4. fuga\n\n')
   })
 })
 

--- a/src/easybooks-ast/review-stringify.test.ts
+++ b/src/easybooks-ast/review-stringify.test.ts
@@ -78,6 +78,12 @@ describe('list', () => {
   })
 })
 
+describe('ordered list', () => {
+  test('', async () => {
+    expect(await mdToReview('1. hoge\n2. fuga')).toBe('1. hoge\n2. fuga\n\n')
+  })
+})
+
 describe('thematic break', () => {
   test('', () => {
     expect(mdToReview('---\n')).resolves.toBe('')

--- a/src/easybooks-ast/review-stringify.test.ts
+++ b/src/easybooks-ast/review-stringify.test.ts
@@ -80,7 +80,7 @@ describe('list', () => {
 
 describe('ordered list', () => {
   test('', async () => {
-    expect(await mdToReview('1. hoge\n2. fuga')).toBe('1. hoge\n2. fuga\n\n')
+    expect(await mdToReview('1. hoge\n2. fuga')).toBe(' 1. hoge\n 2. fuga\n\n')
   })
 })
 

--- a/src/easybooks-ast/review-stringify.ts
+++ b/src/easybooks-ast/review-stringify.ts
@@ -74,7 +74,7 @@ const list = (tree: EBAST.List, context: Context) => {
       .join('') + '\n'
   if (tree.ordered) {
     let count = 1
-    return list.replace(/^ \* /gm, matched => (count++) + '. ')
+    return list.replace(/^ \* /gm, matched => ' ' + (count++) + '. ')
   }
   return list
 }

--- a/src/easybooks-ast/review-stringify.ts
+++ b/src/easybooks-ast/review-stringify.ts
@@ -69,11 +69,14 @@ const linkReference = (tree: EBAST.LinkReference, context: Context) => {
 }
 
 const list = (tree: EBAST.List, context: Context) => {
-  return (
-    tree.children
+  const list = tree.children
       .map(child => compiler(child, { ...context, list: context.list + 1 }))
       .join('') + '\n'
-  )
+  if (tree.ordered) {
+    let count = 1
+    return list.replace(/^ \* /gm, matched => (count++) + '. ')
+  }
+  return list
 }
 
 const listItem = (tree: EBAST.ListItem, context: Context) => {

--- a/src/easybooks-ast/review-stringify.ts
+++ b/src/easybooks-ast/review-stringify.ts
@@ -73,8 +73,8 @@ const list = (tree: EBAST.List, context: Context) => {
       .map(child => compiler(child, { ...context, list: context.list + 1 }))
       .join('') + '\n'
   if (tree.ordered) {
-    let count = 1
-    return list.replace(/^ \* /gm, matched => ' ' + (count++) + '. ')
+    let count = Number(tree.start)
+    return list.replace(/^ \* /gm, () => ' ' + (count++) + '. ')
   }
   return list
 }


### PR DESCRIPTION
https://github.com/kmuto/review/blob/master/doc/format.ja.md#%E7%95%AA%E5%8F%B7%E4%BB%98%E3%81%8D%E7%AE%87%E6%9D%A1%E6%9B%B8%E3%81%8D への対応となります。
Re:VIEWが仕様上一階層しか対応していないとのことなので、その前提で、一旦通常の箇条書きにした上で番号を付け直すというアプローチを取っています。
いかがでしょうか？