### PR TITLE
表の列幅の指定への対応

### DIFF
--- a/src/easybooks-ast/review-stringify.test.ts
+++ b/src/easybooks-ast/review-stringify.test.ts
@@ -169,6 +169,29 @@ describe('table', () => {
     )
   })
 
+  test('GFM table with column width', () => {
+    expect(
+      mdToReview(
+        [
+          '|@20:title1|@30:title2|@50:title3|',
+          '|-----|-----|----|',
+          '|hoge|fuga|piyo|',
+          '',
+        ].join('\n'),
+      ),
+    ).resolves.toBe(
+      [
+        '//tsize[|latex||p{20mm}l|p{30mm}l|p{50mm}l|]',
+        '//table[-000][]{',
+        'title1\ttitle2\ttitle3',
+        '--------------------------',
+        'hoge\tfuga\tpiyo',
+        '//}',
+        '',
+      ].join('\n'),
+    )
+  })
+
   test('GFM table left/center/right align', () => {
     expect(
       mdToReview(

--- a/src/easybooks-ast/review-stringify.test.ts
+++ b/src/easybooks-ast/review-stringify.test.ts
@@ -181,7 +181,7 @@ describe('table', () => {
       ),
     ).resolves.toBe(
       [
-        '//tsize[|latex||p{20mm}l|p{30mm}l|p{50mm}l|]',
+        '//tsize[|latex||p{20mm}|p{30mm}|p{50mm}|]',
         '//table[-000][]{',
         'title1\ttitle2\ttitle3',
         '--------------------------',

--- a/src/easybooks-ast/review-stringify.test.ts
+++ b/src/easybooks-ast/review-stringify.test.ts
@@ -173,7 +173,7 @@ describe('table', () => {
     expect(
       mdToReview(
         [
-          '|@20:title1|@30:title2|@50:title3|',
+          '|{width=20}title1|{width=30}title2|{width=50}title3|',
           '|-----|-----|----|',
           '|hoge|fuga|piyo|',
           '',

--- a/src/easybooks-ast/review-stringify.ts
+++ b/src/easybooks-ast/review-stringify.ts
@@ -138,6 +138,11 @@ const TableAlign = {
   center: 'c',
   right: 'r',
 }
+const TableAlignWithWidth = {
+  left: 'p',
+  center: 'm',
+  right: 'b',
+}
 
 const table = (tree: EBAST.Table, context: Context) => {
   const colWidthes: string[] = []
@@ -161,8 +166,12 @@ const table = (tree: EBAST.Table, context: Context) => {
     lines.push(
       `//tsize[|latex||${tree.align
         .map((align, index) => {
-          const width = colWidthes[index] ? `p{${colWidthes[index]}mm}` : ''
-          return `${width}${TableAlign[align || 'left']}`
+          const width = colWidthes[index]
+          if (width) {
+            return `${TableAlignWithWidth[align || 'left']}{${width}mm}`
+          } else {
+            return TableAlign[align || 'left']
+          }
         })
         .join('|')}|]`,
     )

--- a/src/easybooks-ast/review-stringify.ts
+++ b/src/easybooks-ast/review-stringify.ts
@@ -150,11 +150,15 @@ const table = (tree: EBAST.Table, context: Context) => {
     let row = compiler(child, context)
     if (index == 0) {
       row = row.split('\t').map(column => {
-        const content = column.replace(/^(\s*)@([0-9]+):\s*/, '$1')
-        if (RegExp.$2) {
-          colWidthes.push(RegExp.$2)
+        const matcher = /^(\s*)@([0-9]+):\s*/
+        const colWidthMatched = column.match(matcher)
+        if (colWidthMatched) {
+          const content = column.replace(matcher, '$1')
+          colWidthes.push(colWidthMatched[2])
+          return content
+        } else {
+          return column
         }
-        return content
       }).join('\t')
     }
     return row


### PR DESCRIPTION
Re:VIEWの仕様上は列幅の指定ができる https://github.com/kmuto/review/blob/master/doc/format.ja.md#%E8%A1%A8%E3%81%AE%E5%88%97%E5%B9%85  のですが、現行版では列幅の情報を与える方法がありません。
GFMの仕様上も列幅に関する使用は無い模様でしたので、試験的に、独自の記法で列幅を指定できるようにしてみました。

```
|@10: あああ |@20: いいい |@30: ううう |
| --- | --- | --- |
| あああ | いいい | ううう |
```

このように「@数値:」をヘッダ行の各セルの先頭に書くと、数値をその列の幅（mm）として採用する、という仕様にしています。

自分はMarkdown、Re:VIEWのいずれについても素人のため、この記法が妥当かどうかについて判断材料を持っていない状態です。
どう思われますでしょうか？