### PR TITLE
番号付きの箇条書きと、複雑な箇条書きの入れ子に対応

### DIFF
--- a/src/easybooks-ast/review-stringify.test.ts
+++ b/src/easybooks-ast/review-stringify.test.ts
@@ -75,6 +75,24 @@ describe('list', () => {
     expect(await mdToReview('* hoge\n  - fuga')).toBe(
       ' * hoge\n ** fuga\n\n',
     )
+    expect(await mdToReview('* hoge\n  \n  ```\n  list\n  ```\n* fuga')).toBe(
+      ' * hoge\n//child[ul]\n//listnum[-000][]{\nlist\n//}\n//child[/ul]\n * fuga\n\n'
+    )
+    expect(await mdToReview('* hoge\n  ![image]()\n* fuga')).toBe(
+      ' * hoge\n//child[ul]\n//image[][image]\n//child[/ul]\n * fuga\n\n'
+    )
+  })
+})
+
+describe('ordered list', () => {
+  test('', async () => {
+    expect(await mdToReview('1. hoge\n2. fuga')).toBe(' 1. hoge\n 2. fuga\n\n')
+    expect(await mdToReview('1. hoge\n  \n  ```\n  list\n  ```\n2. fuga')).toBe(
+      ' 1. hoge\n//child[ol]\n//listnum[-000][]{\nlist\n//}\n//child[/ol]\n 2. fuga\n\n'
+    )
+    expect(await mdToReview('1. hoge\n  ![image]()\n1. fuga')).toBe(
+      ' 1. hoge\n//child[ol]\n//image[][image]\n//child[/ol]\n 2. fuga\n\n'
+    )
   })
 })
 

--- a/src/easybooks-ast/review-stringify.ts
+++ b/src/easybooks-ast/review-stringify.ts
@@ -71,16 +71,31 @@ const linkReference = (tree: EBAST.LinkReference, context: Context) => {
 const list = (tree: EBAST.List, context: Context) => {
   return (
     tree.children
-      .map(child => compiler(child, { ...context, list: context.list + 1 }))
+      .map((child, index) => compiler(child, {
+        ...context,
+        list:    context.list + 1,
+        ordered: tree.ordered,
+        index:   index + 1
+      }))
       .join('') + '\n'
   )
 }
 
 const listItem = (tree: EBAST.ListItem, context: Context) => {
-  return ` ${'*'.repeat(context.list)} ${tree.children
+  const children = tree.children
     .map(child => compiler(child, context))
     .join('')
-    .trim()}\n`
+    .trim()
+    .split('\n')
+  const content = children.length > 1 ? children.slice(1).join('\n') : ''
+  if (/^\s*\/\//m.test(content)) {
+    const bullet = context.ordered ? `${context.index}.` : '*'
+    const tag = context.ordered ? 'ol' : 'ul'
+    return ` ${bullet} ${children[0]}\n//child[${tag}]\n${content}\n//child[/${tag}]\n`
+  } else {
+    const bullet = context.ordered ? `${context.index}.` : '*'.repeat(context.list)
+    return ` ${bullet} ${children.join('\n')}\n`
+  }
 }
 
 const ignore = (tree: any, context: Context) => ''

--- a/src/easybooks-ast/review-stringify.ts
+++ b/src/easybooks-ast/review-stringify.ts
@@ -4,6 +4,8 @@ interface Context {
   list: number
   id: number
   chapter: string
+  index?: number
+  ordered?: boolean
 }
 
 const getId = (context: Context) => {
@@ -74,7 +76,7 @@ const list = (tree: EBAST.List, context: Context) => {
       .map((child, index) => compiler(child, {
         ...context,
         list:    context.list + 1,
-        ordered: tree.ordered,
+        ordered: tree.ordered || false,
         index:   index + 1
       }))
       .join('') + '\n'


### PR DESCRIPTION
#6 の別案として、複雑な箇条書きの入れ子（ https://review-knowledge-ja.readthedocs.io/ja/latest/reviewext/nest.html ）への対応も盛り込んだ、番号付き箇条書きへの対応案です。
コードブロックなどが含まれている場合、`//child[～]`を使った入れ子記法に切り替えるようにしております。
いかがでしょうか？