### PR TITLE
番号無しのリストを出力できない制限への対案

### DIFF
--- a/src/easybooks-ast/ebast.ts
+++ b/src/easybooks-ast/ebast.ts
@@ -103,6 +103,7 @@ export interface Code extends Literal {
     startLine?: number
     endLine?: number
   }
+  num?: boolean
 }
 
 export interface YAML extends Literal {

--- a/src/easybooks-ast/md-to-eb.ts
+++ b/src/easybooks-ast/md-to-eb.ts
@@ -26,10 +26,11 @@ export const parseMeta = (meta: string): { [props: string]: string } => {
 }
 
 const enterCode = (node: MDAST.Code & EBAST.Code) => {
-  const { id, caption, src, filename } = parseMeta(node.meta || '')
+  const { id, caption, src, filename, num } = parseMeta(node.meta || '')
   node.id = id
   node.caption = caption
   node.filename = filename
+  node.num = num === undefined ? true : num.toLowerCase() == 'true'
 
   if (src) {
     const [url, lines] = src.split('#')

--- a/src/easybooks-ast/review-stringify.test.ts
+++ b/src/easybooks-ast/review-stringify.test.ts
@@ -67,6 +67,12 @@ describe('code block', () => {
       await mdToReview('```js {id=hoge caption=ほげ}\nconst a = 1\n```\n'),
     ).toBe('//listnum[hoge][ほげ][js]{\nconst a = 1\n//}\n')
   })
+
+  test('option num', async () => {
+    expect(await mdToReview('```text {num=false}\n$ hoge\n```\n')).toBe(
+      '//list[-000][][text]{\n$ hoge\n//}\n',
+    )
+  })
 })
 
 describe('list', () => {

--- a/src/easybooks-ast/review-stringify.ts
+++ b/src/easybooks-ast/review-stringify.ts
@@ -49,7 +49,8 @@ const code = (tree: EBAST.Code, context: Context) => {
     return `//cmd{\n${tree.value}\n//}\n`
   }
 
-  return `//listnum[${(tree.id || getId(context)).replace(
+  const num = tree.num ? 'num' : ''
+  return `//list${num}[${(tree.id || getId(context)).replace(
     '}',
     '\\}',
   )}][${tree.caption || ''}]${lang}{\n${tree.value}\n//}\n`


### PR DESCRIPTION
現在の版では、コードブロックは言語がshとそれ以外の2択になっており、sh以外では常にリストの各行に番号が付くようになっています。
そのため、番号無しのリストを出力したいというニーズ（HTMLの`<pre>`を使いたいような場面）に対応できません。

そこで、numというオプションを導入し、`num=false`と指定した場合は番号付けの無いリストにする、という挙動を実装してみました。
（既定値は`num=true`にあたり、基本動作は番号付けありとなります。）
`nonum=true`とする方が実装としては簡潔になるのですが、仕様が分かりにくくなるため、仕様の分かりやすさを優先してこのようにした次第です。

いかがでしょうか？