### PR TITLE
"*.re"（Re:VIEW形式のファイル名）を部構成のキーに指定できるようにした

### DIFF
--- a/src/adapters/review/tasks.ts
+++ b/src/adapters/review/tasks.ts
@@ -59,6 +59,9 @@ export const createCatalog = (
             const reviewFilename = key.replace(/\.md$/, '.re')
             tasks.push(convert(files, key, reviewFilename))
             namedEntry[reviewFilename] = filename[key].map(processEntry)
+          } else if (key.endsWith('.re')) {
+            tasks.push(files.exportFileToDisk(key))
+            namedEntry[key] = filename[key].map(processEntry)
           } else {
             namedEntry[key] = filename[key].map(processEntry)
           }
@@ -69,10 +72,7 @@ export const createCatalog = (
         tasks.push(convert(files, filename, reviewFilename))
         return reviewFilename
       } else {
-        const copy = async () => {
-          await files.exportFileToDisk(filename)
-        }
-        tasks.push(copy())
+        tasks.push(files.exportFileToDisk(filename))
         return filename
       }
     }


### PR DESCRIPTION
すみません。#4 の実装に見落としがあり、部構成のキーに.mdのファイル名は受け付けるようになっていましたが、.reのファイル名を受け付けない状態になってしまっておりました。

コピーするファイル名が配列の各要素固定でなくなってしまったため、copy()を削除してfiles.exportFileToDisk()を直接呼ぶようにしましたが、copy()に引数としてファイル名を指定できるようにする方が正道でしょうか？
ご意見を頂けましたら幸いです。