### PR TITLE
章参照への対応

### DIFF
--- a/src/easybooks-ast/review-stringify.test.ts
+++ b/src/easybooks-ast/review-stringify.test.ts
@@ -39,6 +39,53 @@ describe('paragraph', () => {
   })
 })
 
+describe('chapter reference', () => {
+  test('chapter number', async () => {
+    const links = [
+      '[1章](first.md)',
+      '[第2章](second.md)',
+      '[第X章](third.md)',
+      '[1 章](first.re)',
+      '[第 2 章](second.re)',
+      '[第 X 章](third.re)',
+    ]
+    expect(await mdToReview(links.join(','))).toBe(
+      '\n@<chap>{first},@<chap>{second},@<chap>{third},' +
+        '@<chap>{first},@<chap>{second},@<chap>{third}\n',
+    )
+  })
+
+  test('chapter title', async () => {
+    const links = [
+      '[最初](first.md)',
+      '[次](second.md)',
+      '[今度](third.md)',
+      '[任意の](first.re)',
+      '[文字列](second.re)',
+      '[](third.re)',
+    ]
+    expect(await mdToReview(links.join(','))).toBe(
+      '\n@<title>{first},@<title>{second},@<title>{third},' +
+        '@<title>{first},@<title>{second},@<title>{third}\n',
+    )
+  })
+
+  test('chapter number and title', async () => {
+    const links = [
+      '[第1章 最初](first.md)',
+      '[2章 次](second.md)',
+      '[第N章 今度](third.md)',
+      '[第*章 任意の](first.re)',
+      '[第?章 文字列](second.re)',
+      '[第n章 タイトル](third.re)',
+    ]
+    expect(await mdToReview(links.join(','))).toBe(
+      '\n@<chapref>{first},@<chapref>{second},@<chapref>{third},' +
+        '@<chapref>{first},@<chapref>{second},@<chapref>{third}\n',
+    )
+  })
+})
+
 describe('code block', () => {
   test('no lang', async () => {
     expect(await mdToReview('```\nほげ\n```\n')).toBe(

--- a/src/easybooks-ast/review-stringify.ts
+++ b/src/easybooks-ast/review-stringify.ts
@@ -62,6 +62,16 @@ const code = (tree: EBAST.Code, context: Context) => {
 
 const link = (tree: EBAST.Link, context: Context) => {
   const s = tree.children.map(child => compiler(child, context)).join('')
+  if (/^[^\/]+\.(md|re)$/i.test(tree.url)) {
+	const chapterId = tree.url.replace(/\.(md|re)$/, '')
+    if (/^第?[0-9a-z?* ]+章$/i.test(s)) {
+      return `@<chap>{${chapterId}}`
+    }
+    else if (/^第?[0-9a-z?* ]+章/i.test(s)) {
+      return `@<chapref>{${chapterId}}`
+    }
+    return `@<title>{${chapterId}}`
+  }
   return `@<href>{${tree.url}${s ? `, ${s}` : ''}}`
 }
 


### PR DESCRIPTION
https://github.com/kmuto/review/blob/master/doc/format.ja.md#%E8%A6%8B%E5%87%BA%E3%81%97%E5%8F%82%E7%85%A7 の仕様のうち、章への参照に対応する変更です。
特殊な記法を導入するのではなく、Markdownとしての原稿上で自然に書くであろうリンク文字列に基づいて、以下のように参照の形式を推測する仕様としてみました。

* リンク先が同階層のmdまたはreファイルであれば、章への参照と見なす。
* リンク文字列が「第N章」のように章番号であれば、章番号の参照と見なす。
* リンク文字列が「第N章 何々」のように章番号＋任意のテキストであれば、章番号＋章タイトルの参照と見なす。
* それ以外の場合、章タイトルの参照と見なす。

いかがでしょうか？